### PR TITLE
%TABLE% should be uppercase

### DIFF
--- a/Adapter/DoctrineORMAdapter.php
+++ b/Adapter/DoctrineORMAdapter.php
@@ -30,7 +30,7 @@ class DoctrineORMAdapter extends SqlAdapter
      */
     protected function exec($query, array $args)
     {
-        $sth = $this->dbal->prepare(strtr($query, array('%table%' => $this->table)));
+        $sth = $this->dbal->prepare(strtr($query, array('%TABLE%' => $this->table)));
         $sth->execute($args);
     }
 


### PR DESCRIPTION
After %table% was made uppercase in commit 020cecb627dad9e9dd571ae8bce565541d2c63ee, the DoctrineORMAdapter seems to have been forgotten.